### PR TITLE
docs(utopia_hooks): Clarify shouldCompute & clearOnShouldComputeFalse in usePaginatedComputedState

### DIFF
--- a/packages/hooks/lib/src/hook/complex/paginated/use_paginated_computed_state.dart
+++ b/packages/hooks/lib/src/hook/complex/paginated/use_paginated_computed_state.dart
@@ -27,9 +27,15 @@ import 'package:utopia_hooks/src/hook/nested/use_debug_group.dart';
 /// [initialCursor] is captured on first build. For dynamic starting points, wrap the
 /// hook in `useKeyed` so the state is fully recreated.
 ///
-/// [shouldCompute] gates all loading. When `false`, state is cleared (items drop to
-/// `null`) and any in-progress load is cancelled. When it transitions back to `true`,
-/// the first page is loaded.
+/// [shouldCompute] gates only the automatic loads - the first page on mount and the
+/// refresh triggered by [keys] changes. When `false`, those loads are skipped, but
+/// already-loaded items stay visible and manual [MutablePaginatedComputedState.loadMore]
+/// and [MutablePaginatedComputedState.refresh] calls still work. When it transitions
+/// back to `true`, the first page is loaded.
+///
+/// [clearOnShouldComputeFalse] opts into clearing when [shouldCompute] becomes `false`:
+/// any in-flight load is cancelled and items and error are dropped (items return to
+/// `null`). Defaults to `false`, which leaves existing state untouched.
 ///
 /// [keys] triggers a refresh from [initialCursor] on every change. Items stay visible
 /// until the first page of the new load replaces them — no flicker.


### PR DESCRIPTION
## What

Fixes the doc comment on `usePaginatedComputedState` to match the actual implementation.

The previous documentation was stale/incorrect:
- It claimed `shouldCompute` *"gates all loading"* and that *"when false, state is cleared (items drop to null)"*.
- In reality `shouldCompute` only gates the **automatic** loads (first page on mount + refresh on `keys` changes). Manual `loadMore`/`refresh` keep working regardless.
- Clearing on `shouldCompute == false` happens **only** when the `clearOnShouldComputeFalse` flag is set - a parameter the old doc didn't mention at all.

## Why

Doc-only correction; no behavior change. Verified line-by-line against the `useEffect` gating (`[shouldCompute, ...keys]`) and `clear()` / `refresh()` logic.

## Scope

Single file, documentation comments only. No version bump (`docs` type does not trigger a melos release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)